### PR TITLE
Launch custom overlays and drop legacy OSD

### DIFF
--- a/field_player.py
+++ b/field_player.py
@@ -6,6 +6,9 @@ import datetime
 import json
 import signal
 import logging
+import subprocess
+import sys
+from pathlib import Path
 
 from fs42.liquid_manager import LiquidManager
 from fs42.station_manager import StationManager
@@ -318,6 +321,10 @@ if __name__ == "__main__":
         api_commands_queue = None
         api_proc = None
 
+    osd_dir = Path(__file__).resolve().parent / "fs42" / "osd"
+    overlay_proc = subprocess.Popen([sys.executable, osd_dir / "fsx_overlay.py"])
+    menu_proc = subprocess.Popen([sys.executable, osd_dir / "fsx_menu.py"])
+
     try:
         main_loop(trans_fn, shutdown_queue=shutdown_queue, api_proc=api_proc)
     finally:
@@ -325,3 +332,7 @@ if __name__ == "__main__":
             shutdown_queue.put("shutdown")
         if api_proc is not None:
             api_proc.join(timeout=5)
+        overlay_proc.terminate()
+        menu_proc.terminate()
+        overlay_proc.wait()
+        menu_proc.wait()

--- a/page_stream/example_launcher/example_start_fs42.sh
+++ b/page_stream/example_launcher/example_start_fs42.sh
@@ -82,13 +82,13 @@ echo "[FS42] Launching channel changer..."
 : > "$LOG_DIR/channel_changer.log"
 python3 fs42/change_channel.py > "$LOG_DIR/channel_changer.log" 2>&1 &
 
-echo "[FS42] Launching OSD..."
-: > "$LOG_DIR/osd.log"
-python3 fs42/osd/main.py > "$LOG_DIR/osd.log" 2>&1 &
+echo "[FS42] Launching overlay..."
+: > "$LOG_DIR/fsx_overlay.log"
+python3 fs42/osd/fsx_overlay.py > "$LOG_DIR/fsx_overlay.log" 2>&1 &
 
-sleep 2
-wmctrl -r "FieldStationOSD" -b add,above || echo "[OSD] Failed to raise window"
-wmctrl -a "FieldStationOSD" || echo "[OSD] Failed to focus window"
+echo "[FS42] Launching OSD menu..."
+: > "$LOG_DIR/fsx_menu.log"
+python3 fs42/osd/fsx_menu.py > "$LOG_DIR/fsx_menu.log" 2>&1 &
 
 ########################################
 # 4. Wait Indefinitely


### PR DESCRIPTION
## Summary
- start new fsx_overlay and fsx_menu processes when FieldPlayer launches
- terminate the overlay processes on shutdown
- example launcher now runs the new overlays instead of the legacy OSD

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b55dc7c2708322830b99ce9187d986